### PR TITLE
Rename some keys in configuration

### DIFF
--- a/pibooth_qrcode.py
+++ b/pibooth_qrcode.py
@@ -18,7 +18,7 @@ def pibooth_configure(cfg):
                    "Prefix URL for the QR code")
     cfg.add_option('QRCODE', 'unique_url', True,
                    "Use only one URL for all photos (one QR code linking to the album)",
-                   "Use only one URL", ["True","False"])
+                   "Use only one URL", ["True", "False"])
     cfg.add_option('QRCODE', 'foreground', (255, 255, 255),
                    "QR code foreground color", "Color", (255, 255, 255))
     cfg.add_option('QRCODE', 'background', (0, 0, 0),

--- a/pibooth_qrcode.py
+++ b/pibooth_qrcode.py
@@ -12,21 +12,21 @@ __version__ = "0.0.2"
 @pibooth.hookimpl
 def pibooth_configure(cfg):
     """Declare the new configuration options"""
-    cfg.add_option('QRCODE', 'qrcode_prefix', "https://github.com/pibooth/pibooth",
+    cfg.add_option('QRCODE', 'prefix_url', "https://github.com/pibooth/pibooth",
                    "Prefix URL for the QR code")
     cfg.add_option('QRCODE', 'unique_url', True,
                    "Use only one URL for all photos (one QR code linking to the album)",
                    "Use only one URL", ["True","False"])
-    cfg.add_option('QRCODE', 'code_foreground', (255, 255, 255),
-                   "QR code foreground color", "QR code color", (255, 255, 255))
-    cfg.add_option('QRCODE', 'code_background', (0, 0, 0),
-                   "QR code background color", "QR background color", (0 ,0 ,0))
+    cfg.add_option('QRCODE', 'foreground', (255, 255, 255),
+                   "QR code foreground color", "Color", (255, 255, 255))
+    cfg.add_option('QRCODE', 'background', (0, 0, 0),
+                   "QR code background color", "Background color", (0 ,0 ,0))
 
 @pibooth.hookimpl
 def pibooth_startup(cfg, app):
     """Store the qrcode prefix as an attribute of the app
     """
-    app.qrcode_prefix = cfg.get('QRCODE', 'qrcode_prefix')
+    app.qrcode_prefix = cfg.get('QRCODE', 'prefix_url')
 
 @pibooth.hookimpl
 def state_wait_enter(app, win):
@@ -57,8 +57,8 @@ def state_processing_exit(app, cfg):
     qr.add_data(os.path.join(app.qrcode_prefix, name))
     qr.make(fit=True)
 
-    qrcode_fill_color = '#%02x%02x%02x' %cfg.gettyped("QRCODE", 'code_foreground')
-    qrcode_background_color = '#%02x%02x%02x' % cfg.gettyped("QRCODE", 'code_background')
+    qrcode_fill_color = '#%02x%02x%02x' %cfg.gettyped("QRCODE", 'foreground')
+    qrcode_background_color = '#%02x%02x%02x' % cfg.gettyped("QRCODE", 'background')
 
     image = qr.make_image(fill_color=qrcode_fill_color, back_color=qrcode_background_color)
     app.previous_qr = pygame.image.fromstring(image.tobytes(), image.size, image.mode)


### PR DESCRIPTION
Just a proposal: config key are in the section "QRCODE", thus there is no need to use "code" or "qrcode" in the name of the key.
Anyway, it is implementation details, feel free to cancel this PR :relaxed: