### PR TITLE
Fix #11: try import qrcode to let the setup.py run

### DIFF
--- a/pibooth_qrcode.py
+++ b/pibooth_qrcode.py
@@ -2,7 +2,10 @@
 
 """Pibooth plugin to display a QR Code on the screen during idle time."""
 
-import qrcode
+try:
+    import qrcode
+except ImportError:
+    pass  # When running the setup.py, qrcode is not yet installed
 import pygame
 import pibooth
 from pibooth.view.background import multiline_text_to_surfaces

--- a/pibooth_qrcode.py
+++ b/pibooth_qrcode.py
@@ -5,6 +5,7 @@
 try:
     import qrcode
 except ImportError:
+    qrcode = None
     pass  # When running the setup.py, qrcode is not yet installed
 import pygame
 import pibooth
@@ -133,6 +134,8 @@ def state_processing_exit(cfg, app):
     """
     Generate the QR Code and store it in the application.
     """
+    if qrcode is None:
+        raise ModuleNotFoundError("No module named 'qrcode'")
     qr = qrcode.QRCode(version=1,
                        error_correction=qrcode.constants.ERROR_CORRECT_L,
                        box_size=3,


### PR DESCRIPTION
Not a very smart solution.
In fact, the setup import the plugin, and the plugin import uninstalled lib.

I think that it is the same for all plugin that need external lib.